### PR TITLE
RabbitMQ vhost can be configured (part 2/3)

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -4,6 +4,7 @@ LABEL maintainer="Mathieu BRUNOT <mathieu.brunot at monogramm dot io>"
 
 # Taiga back and events properties
 ENV TAIGA_VERSION=%%VERSION%% \
+    RABBIT_VHOST=/ \
     RABBIT_USER=guest \
     RABBIT_PASSWORD=guest \
     RABBIT_HOST=taigarabbit \

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ RABBIT_USER=guest
 RABBIT_PASSWORD=guest
 RABBIT_HOST=rabbitmq
 RABBIT_PORT=5672
+RABBIT_VHOST=/
 ```
 
 Configures RabbitMQ. Requires RabbitMQ.
@@ -80,6 +81,7 @@ RABBIT_USER=taiga
 RABBIT_PASSWORD=somethingverysecure
 RABBIT_HOST=taiga_rabbitmq
 RABBIT_PORT=5672
+RABBIT_VHOST=/taiga
 ```
 
 ### TAIGA_EVENTS_SECRET

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,7 +12,7 @@ fi
 if [ -n "$RABBIT_HOST" ]; then
   echo "Updating Taiga RabbitMQ URL: $RABBIT_HOST"
   sed -i \
-    -e "s|\"url\": \".*\",|\"url\": \"amqp://${RABBIT_USER}:${RABBIT_PASSWORD}@${RABBIT_HOST}:${RABBIT_PORT}\",|g" \
+    -e "s|\"url\": \".*\",|\"url\": \"amqp://${RABBIT_USER}:${RABBIT_PASSWORD}@${RABBIT_HOST}:${RABBIT_PORT}/${RABBIT_VHOST}\",|g" \
     /taiga/config.json
 fi
 

--- a/images/master/alpine/Dockerfile
+++ b/images/master/alpine/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Mathieu BRUNOT <mathieu.brunot at monogramm dot io>"
 
 # Taiga back and events properties
 ENV TAIGA_VERSION=master \
+    RABBIT_VHOST=/ \
     RABBIT_USER=guest \
     RABBIT_PASSWORD=guest \
     RABBIT_HOST=taigarabbit \

--- a/images/master/alpine/entrypoint.sh
+++ b/images/master/alpine/entrypoint.sh
@@ -12,7 +12,7 @@ fi
 if [ -n "$RABBIT_HOST" ]; then
   echo "Updating Taiga RabbitMQ URL: $RABBIT_HOST"
   sed -i \
-    -e "s|\"url\": \".*\",|\"url\": \"amqp://${RABBIT_USER}:${RABBIT_PASSWORD}@${RABBIT_HOST}:${RABBIT_PORT}\",|g" \
+    -e "s|\"url\": \".*\",|\"url\": \"amqp://${RABBIT_USER}:${RABBIT_PASSWORD}@${RABBIT_HOST}:${RABBIT_PORT}/${RABBIT_VHOST}\",|g" \
     /taiga/config.json
 fi
 


### PR DESCRIPTION
In a larger docker deployment, RabbitMQ might be used by more applications than Taiga. Separation then happens using RabbitMQ vhosts. This patch changes docker-entrypoint.sh to use an environment variable to configure said vhost and adds default value of `/` so that existing deployments are not affected.

Respective pull requests are being made to Monogramm/docker-taiga-back-base#20 and Monogramm/docker-taiga#32